### PR TITLE
Updated Accelerator and VQE to work with measurement bases

### DIFF
--- a/quantum/observable/pauli/PauliOperator.cpp
+++ b/quantum/observable/pauli/PauliOperator.cpp
@@ -212,7 +212,6 @@ PauliOperator::observe(std::shared_ptr<CompositeInstruction> function) {
   auto it1 = basisRotations.begin();
   auto it2 = terms.begin();
   for (; it1 != basisRotations.end() && it2 != terms.end(); ++it1, ++it2) {
-
     Term spinInst = (*it2).second;
 
     auto gateFunction =
@@ -1138,7 +1137,9 @@ std::vector<std::shared_ptr<CompositeInstruction>> PauliOperator::getMeasurement
         terms.push_back({kv.first, kv.second});
       }
     }
+
     auto rotationGates = gateRegistry->createComposite(inst.first);
+    rotationGates->setCoefficient(spinInst.coeff());
     std::vector<std::size_t> measureIdxs;
     for (int i = terms.size() - 1; i >= 0; i--) {
 
@@ -1167,9 +1168,8 @@ std::vector<std::shared_ptr<CompositeInstruction>> PauliOperator::getMeasurement
           meas->setBufferNames({buf_name});
         rotationGates->addInstruction(meas);
       }
-    basisRotations.push_back(rotationGates);
+      basisRotations.push_back(rotationGates);
   }
-
   return basisRotations;
 }
 

--- a/quantum/plugins/algorithms/vqe/vqe.hpp
+++ b/quantum/plugins/algorithms/vqe/vqe.hpp
@@ -26,7 +26,8 @@ protected:
   Accelerator * accelerator;
   std::vector<double> initial_params;
   std::shared_ptr<AlgorithmGradientStrategy> gradientStrategy;
-
+  mutable std::vector<std::shared_ptr<CompositeInstruction>> basisRotations;
+  bool cacheMeasurements;
   HeterogeneousMap parameters;
 
 public:

--- a/quantum/plugins/qsim/accelerator/QsimAccelerator.hpp
+++ b/quantum/plugins/qsim/accelerator/QsimAccelerator.hpp
@@ -319,6 +319,9 @@ public:
   virtual void execute(std::shared_ptr<AcceleratorBuffer> buffer,
                        const std::vector<std::shared_ptr<CompositeInstruction>>
                            compositeInstructions) override;
+  void execute(std::shared_ptr<AcceleratorBuffer> buffer,
+          const std::shared_ptr<CompositeInstruction> baseCircuit,
+          const std::vector<std::shared_ptr<CompositeInstruction>> basisRotations) override;
   virtual void apply(std::shared_ptr<AcceleratorBuffer> buffer,
                      std::shared_ptr<Instruction> inst) override;
 

--- a/xacc/accelerator/Accelerator.hpp
+++ b/xacc/accelerator/Accelerator.hpp
@@ -100,6 +100,13 @@ public:
                        const std::vector<std::shared_ptr<CompositeInstruction>>
                            CompositeInstructions) = 0;
 
+  virtual void
+  execute(std::shared_ptr<AcceleratorBuffer> buffer,
+          const std::shared_ptr<CompositeInstruction> baseCircuit,
+          const std::vector<std::shared_ptr<CompositeInstruction>> basisRotations) {
+    return;
+  }
+
   virtual void cancel(){};
 
   virtual std::vector<std::pair<int, int>> getConnectivity() {


### PR DESCRIPTION
This PR:

- Defines `Accelerator::execute(buffer, baseState, rotationBasis)` and implements it for qsim. This is more efficient because avoids calling `Observable::observe()` multiple times, effectively calling it only once.
- Updated VQE to work with measurement basis rotations, which is enabled via the `cache-measurement-basis` key in the VQE parameters, and take a `bool` as value.