### PR TITLE
Update nlohmann_json to 3.11

### DIFF
--- a/quantum/plugins/ibm/accelerator/IBMAccelerator.cpp
+++ b/quantum/plugins/ibm/accelerator/IBMAccelerator.cpp
@@ -187,7 +187,7 @@ bool hasMidCircuitMeasurement(
 }
 
 bool IBMAccelerator::verifyJobsLimit(std::string& curr_backend) {
-  
+
   // Get backend jobs limit
   std::string getJobsLimitPath = "/api/Network/" + hub + "/Groups/" + group +
                         "/Projects/" + project + "/devices/" + curr_backend +
@@ -204,13 +204,13 @@ bool IBMAccelerator::verifyJobsLimit(std::string& curr_backend) {
 }
 
 void IBMAccelerator::processBackendCandidate(nlohmann::json& backend_json) {
-  // First of all filter by count fo qubits  
+  // First of all filter by count fo qubits
   if (requested_n_qubits > 0) {
     if( backend_json.count("n_qubits") ) {
       int nqubits = backend_json["n_qubits"].get<int>();
       if(nqubits < requested_n_qubits) {
         return;
-      } 
+      }
     } else {
       return;
     }
@@ -449,8 +449,7 @@ std::string QasmQObjGenerator::getQObjJsonStr(
   qobj.set_header(qobjHeader);
 
   // Create the JSON String to send
-  nlohmann::json j;
-  nlohmann::to_json(j, qobj);
+  nlohmann::json j = qobj;
 
   return j.dump();
 }
@@ -561,8 +560,7 @@ std::string PulseQObjGenerator::getQObjJsonStr(
   root.set_backend(b);
   root.set_shots(shots);
 
-  nlohmann::json jj;
-  nlohmann::to_json(jj, root.get_q_object());
+  nlohmann::json jj= root.get_q_object();
   return jj.dump();
 }
 
@@ -1020,7 +1018,7 @@ void IBMAccelerator::contributeInstructions(
               pulseParams["duration"].get<int>();
           inst->setDuration(parametricPulseDuration);
         }
-        
+
         // Delay pulse has a duration
         if (inst_name == "delay") {
           inst->setDuration((*seq_iter)["duration"].get<int>());
@@ -1320,7 +1318,7 @@ IBMAccelerator::getNativeCode(std::shared_ptr<CompositeInstruction> program,
             // qc.qasm() breaks when circuit qc contains gates with classical conditioning on a single cbit
             // Please note that this is a limitation of **OpenQASM** only,
             // i.e., qiskit's QuantumCircuit and QObj can both handle classical conditioning on a single cbit.
-            // Our native code gen strategy here is to 
+            // Our native code gen strategy here is to
             // convert multi-qreg indexing into multiple single-cbit registers:
             // i.e., c[3] -> c3 (single-bit register)
             // This only happens when classical conditioning on a single cbit is needed.

--- a/quantum/plugins/ibm/accelerator/QObjectExperimentVisitor.hpp
+++ b/quantum/plugins/ibm/accelerator/QObjectExperimentVisitor.hpp
@@ -65,9 +65,7 @@ public:
   }
 
   const std::string toString() override {
-    experiment = getExperiment();
-    nlohmann::json json;
-    nlohmann::to_json(json, experiment);
+    nlohmann::json json = getExperiment();
     return json.dump();
   }
 
@@ -106,7 +104,7 @@ public:
       experiment.set_config(config);
       experiment.set_header(header);
       //   xacc::info("Adding insts " + std::to_string(instructions.to))
-      
+
       // Note: the experiment was constructed in terms of { u1, u2, u3, cx} gate set.
       // U + CX gate set
       if (gateSet == GateSet::U_CX) {
@@ -126,7 +124,7 @@ public:
             // Copy the instruction and only update the name + params.
             // This is to make sure information about Bfunc (conditional) etc.
             // is copied to the decomposed gate sequence.
-            
+
             // Note: this decomposition is adapted from Qiskit Terra,
             // see qiskit/circuit/library/standard_gates/equivalence_library.py
             const auto u2_params = inst.get_params();

--- a/quantum/plugins/ibm/compiler/QObjectCompiler.cpp
+++ b/quantum/plugins/ibm/compiler/QObjectCompiler.cpp
@@ -40,7 +40,7 @@ std::shared_ptr<IR> QObjectCompiler::compile(const std::string &src,
   auto ir = provider->createIR();
   auto json = nlohmann::json::parse(jsonstr);
   xacc::ibm::QObjectRoot qobj;
-  nlohmann::from_json(json, qobj);
+  json.get_to(qobj);
 
   auto experiments = qobj.get_q_object().get_experiments();
   for (auto &e : experiments) {
@@ -108,7 +108,7 @@ QObjectCompiler::translate(std::shared_ptr<xacc::CompositeInstruction> function)
 
   auto uniqueBits = function->uniqueBits();
   // The number of qubits required for an experiment is the number of *physical* qubits,
-  // i.e. the max index of qubit used in the circuit.  
+  // i.e. the max index of qubit used in the circuit.
   auto nbRequiredBits = function->nPhysicalBits();
   auto visitor =
       std::make_shared<QObjectExperimentVisitor>(function->name(), nbRequiredBits);
@@ -152,8 +152,7 @@ QObjectCompiler::translate(std::shared_ptr<xacc::CompositeInstruction> function)
   root.set_q_object(qobj);
 
   // Create the JSON String to send
-  nlohmann::json j;
-  nlohmann::to_json(j, root);
+  nlohmann::json j = root;
   return j.dump();
 }
 
@@ -220,8 +219,7 @@ QObjectCompiler::translate(std::shared_ptr<CompositeInstruction> function,
   root.set_q_object(qobj);
 
   // Create the JSON String to send
-  nlohmann::json j;
-  nlohmann::to_json(j, root);
+  nlohmann::json j = root;
   return j.dump();
 }
 } // namespace quantum


### PR DESCRIPTION
This updates nlohmann json from 3.1 to 3.11 (6 years of delta) so we can use contemporary distributions of the dependencies with #24.