### PR TITLE
Removed armadillo from PauliOperator

### DIFF
--- a/quantum/observable/pauli/CMakeLists.txt
+++ b/quantum/observable/pauli/CMakeLists.txt
@@ -25,8 +25,7 @@ usFunctionGenerateBundleInit(TARGET ${LIBRARY_NAME} OUT SRC)
 add_library(${LIBRARY_NAME} SHARED ${SRC})
 target_include_directories(${LIBRARY_NAME}
                             PUBLIC
-                            . ${CMAKE_SOURCE_DIR}/tpls/armadillo
-                            ${CMAKE_SOURCE_DIR}/tpls/antlr/runtime/src
+                            . ${CMAKE_SOURCE_DIR}/tpls/antlr/runtime/src
                             ${CMAKE_CURRENT_SOURCE_DIR}
                             ${CMAKE_CURRENT_SOURCE_DIR}/generated
                             ${CMAKE_SOURCE_DIR}/tpls/taocpp

--- a/quantum/plugins/algorithms/gradient_strategies/CMakeLists.txt
+++ b/quantum/plugins/algorithms/gradient_strategies/CMakeLists.txt
@@ -21,7 +21,7 @@ add_library(${LIBRARY_NAME} SHARED ${SRC})
 
 target_include_directories(
   ${LIBRARY_NAME}
-  PUBLIC .)
+  PUBLIC . ${CMAKE_SOURCE_DIR}/tpls/armadillo)
 
 target_link_libraries(${LIBRARY_NAME} PUBLIC xacc CppMicroServices PRIVATE xacc-quantum-gate)
 


### PR DESCRIPTION
With this PR, `PauliOperator` relies exclusively on `Eigen` for linear algebra.