### PR TITLE
FermionOperator bindings for getTerms

### DIFF
--- a/quantum/observable/fermion/FermionOperator.hpp
+++ b/quantum/observable/fermion/FermionOperator.hpp
@@ -197,6 +197,16 @@ public:
   std::shared_ptr<Observable> normalOrder() override;
   
   std::vector<std::shared_ptr<CompositeInstruction>> getMeasurementBasisRotations() override;
+ 
+  std::vector<std::shared_ptr<Observable>> getSubTerms() override {
+    std::vector<std::shared_ptr<Observable>> ret;
+    for (auto &term : getTerms()) {
+      ret.emplace_back(
+          new FermionOperator(term.second.ops(), term.second.coeff()));
+    }
+    return ret;
+  }
+
   
 };
 

--- a/quantum/python/xacc-quantum-py.cpp
+++ b/quantum/python/xacc-quantum-py.cpp
@@ -158,7 +158,8 @@ void bind_quantum(py::module &m) {
           [](PauliOperator &op) {
             return py::make_iterator(op.begin(), op.end());
           },
-          py::keep_alive<0, 1>());
+          py::keep_alive<0, 1>())
+      .def("commutator", &PauliOperator::commutator);
 
   py::class_<FermionTerm>(k, "FermionTerm")
       .def("coeff", &FermionTerm::coeff)
@@ -192,7 +193,9 @@ void bind_quantum(py::module &m) {
       .def("__repr__", &FermionOperator::toString)
       .def("fromString", &FermionOperator::fromString)
       .def("commutator", &FermionOperator::commutator)
-      .def("hermitianConjugate", &FermionOperator::hermitianConjugate);
+      .def("hermitianConjugate", &FermionOperator::hermitianConjugate)
+      .def("getTerms", &FermionOperator::getTerms)
+      .def("getSubTerms", &FermionOperator::getSubTerms);
 
   k.def("getOperatorPool", [](const std::string &name) {
     return xacc::getService<OperatorPool>(name);


### PR DESCRIPTION
This PR implements `FermionOperator::getSubTerms()` and exposes bindings for it and `FermionOperator::getTerms()`.