### PR TITLE
Fixed VQE missing basis rotation caching in execute(buffer, vector)

### DIFF
--- a/quantum/plugins/algorithms/vqe/vqe.cpp
+++ b/quantum/plugins/algorithms/vqe/vqe.cpp
@@ -342,6 +342,10 @@ VQE::execute(const std::shared_ptr<AcceleratorBuffer> buffer,
   // circuits
   if (cacheMeasurements) {
 
+    if (basisRotations.empty()) {
+      basisRotations = observable->getMeasurementBasisRotations();
+    }
+
     nInstructionsEnergy = basisRotations.size() - 1;
     for (auto it = basisRotations.begin(); it != basisRotations.end();) {
 
@@ -387,6 +391,7 @@ VQE::execute(const std::shared_ptr<AcceleratorBuffer> buffer,
   } else {
     accelerator->execute(tmpBuffer, fsToExec);
   }
+
   auto buffers = tmpBuffer->getChildren();
   for (auto &b : buffers) {
     b->addExtraInfo("parameters", x);


### PR DESCRIPTION
Added a call to `Observable::getMeasurementBasisRotations()` that was missing in the VQE algorithm.