### PR TITLE
Re-init ServiceRegistry on every Initialize() call

### DIFF
--- a/xacc/service/xacc_service.cpp
+++ b/xacc/service/xacc_service.cpp
@@ -20,8 +20,7 @@ using namespace cxxopts;
 namespace xacc {
 // class ServiceRegistry;
 bool serviceAPIInitialized = false;
-std::shared_ptr<ServiceRegistry> serviceRegistry =
-    std::make_shared<ServiceRegistry>();
+std::unique_ptr<ServiceRegistry> serviceRegistry;
 
 void addPluginSearchPath(const std::string path) {
     serviceRegistry->appendSearchPath(path);
@@ -44,6 +43,7 @@ void ServiceAPI_Initialize(int argc, char **argv) {
       rootPath = vm["xacc-root-path"].as<std::string>();
     }
 
+    serviceRegistry = std::make_unique<ServiceRegistry>();
     try {
       serviceRegistry->initialize(rootPath);
     } catch (std::exception &e) {
@@ -60,6 +60,7 @@ void ServiceAPI_Finalize() {
     if (serviceAPIInitialized) {
         serviceAPIInitialized = false;
         serviceRegistry->finalize();
+        serviceRegistry.release();
     }
 }
 

--- a/xacc/service/xacc_service.hpp
+++ b/xacc/service/xacc_service.hpp
@@ -18,7 +18,7 @@
 
 namespace xacc {
 
-extern std::shared_ptr<ServiceRegistry> serviceRegistry;
+extern std::unique_ptr<ServiceRegistry> serviceRegistry;
 extern bool serviceAPIInitialized;
 
 void ServiceAPI_Initialize(int argc, char **argv);


### PR DESCRIPTION
Without this, the sequence of calls

    xacc::Initialize()
    xacc::Finalize()
    xacc::Initialize()

will cause CppMicroservices to throw the following:

    terminate called after throwing an instance of 'std::runtime_error'
      what():  The bundle context is no longer valid

### Testing

I ran `ctest` and did some end-to-end testing with QIR-EE.